### PR TITLE
Allow href for fallback, or main use with class="animatescroll"

### DIFF
--- a/animatescroll.js
+++ b/animatescroll.js
@@ -170,7 +170,7 @@
 
 
 $(document).ready(function() {
-	$('a.animatescroll').click(function() {
+	$('a[data-animatescroll]').click(function() {
 		var href = $.attr(this, 'href');
 		$(href).animatescroll();
 	});

--- a/animatescroll.js
+++ b/animatescroll.js
@@ -155,6 +155,7 @@
             // Scroll the element to the desired position
             $(opts.element).stop().animate({ scrollTop: this.offset().top - this.parent().offset().top + this.parent().scrollTop() - opts.padding}, opts.scrollSpeed, opts.easing);
         }
+	  return false;
     };
     
     // default options
@@ -166,3 +167,11 @@
     };   
     
 }(jQuery));
+
+
+$(document).ready(function() {
+	$('a.animatescroll').click(function() {
+		var href = $.attr(this, 'href');
+		$(href).animatescroll();
+	});
+});


### PR DESCRIPTION
return false; on line 158 allows to add href for fallback for those with js disabled without the default behaviour overriding animatescroll.
Lines 172 to 177 allow that instead of adding the onclick method to the &lt;a&gt; tag you can add class="animatescroll" and animate scroll will be launched with the href contents as the target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rampatra/animatescroll.js/11)
<!-- Reviewable:end -->
